### PR TITLE
Adding support for SunOS / Solaris / illumos UNIX domain sockets.

### DIFF
--- a/c_src/packet_parser.c
+++ b/c_src/packet_parser.c
@@ -27,6 +27,10 @@
 
 #include <ctype.h>
 
+#if defined (__SVR4) && defined (__sun)
+#include <string.h>
+#endif
+
 /* #define INET_DRV_DEBUG 1 */
 #ifdef INET_DRV_DEBUG
 #   define DEBUG 1

--- a/src/afunix.erl
+++ b/src/afunix.erl
@@ -43,7 +43,7 @@
 -endif.
 
 load(Driver) ->
-    Path = code:priv_dir(afunix),
+    Path = priv_dir(),
     case erl_ddll:load(Path, Driver) of
 	ok -> 
 	    ok;
@@ -51,7 +51,20 @@ load(Driver) ->
 	    io:format("Error: ~s\n", [erl_ddll:format_error_int(Error)]),
 	    Err
     end.
-    
+
+priv_dir() ->
+    case code:priv_dir(afunix) of
+	{error, bad_name} ->
+	    case code:which(?MODULE) of
+		Filename when is_list(Filename) ->
+		    filename:join([filename:dirname(Filename), "../priv"]);
+		_ ->
+		    "../priv"
+	    end;
+	Dir ->
+	    Dir
+    end.
+
 %%
 %% Send data on a socket
 %%


### PR DESCRIPTION
Tested this on SmartOS version joyent_20140221T042147Z.

Everything appears to work, including `afunix:get_peercred/1` and `afunix:get_peerpid/1` which these changes most affect.
