### PR TITLE
Add support for building under rebar2 or rebar3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .rebar/
+.rebar3
+_*
 c_src/*.d

--- a/rebar.config
+++ b/rebar.config
@@ -2,7 +2,7 @@
 %% Config file for afunix-application
 {erl_opts, [debug_info]}.
 {plugins, [
-  { pc, {git, "git@github.com:blt/port_compiler.git", {tag, "1.6.0"}}}
+  { pc, {git, "git@github.com:blt/port_compiler.git", {tag, "v1.6.0"}}}
  ]}.
 
 %% change -DDLOG_DEFAULT=DLOG_DEBUG

--- a/rebar.config
+++ b/rebar.config
@@ -1,8 +1,17 @@
 %% -*- erlang -*-
 %% Config file for afunix-application
 {erl_opts, [debug_info]}.
+{plugins, [
+  { pc, {git, "git@github.com:blt/port_compiler.git", {tag, "1.6.0"}}}
+ ]}.
+
 %% change -DDLOG_DEFAULT=DLOG_DEBUG
 {port_env, [{"CFLAGS", "$CFLAGS -Wall -DDLOG_DEFAULT=DLOG_NONE"}]}.
+{port_specs, [{"priv/afunix_drv.so",
+               ["c_src/packet_parser.c", "c_src/afunix_drv.c"]}]}.
+{so_name, "afunix_drv.so"}.
+{artifacts, ["priv/afunix_drv.so"]}.
+{provider_hooks, [{pre,[{compile, {pc, compile}}, {clean, {pc, clean}}]}]}.
 
 {ct_extra_params, "-suite test/afunix_api_SUITE -erl_args -name ct"}.
 %% You can also run ct from the test dir using:

--- a/rebar.config
+++ b/rebar.config
@@ -2,7 +2,7 @@
 %% Config file for afunix-application
 {erl_opts, [debug_info]}.
 {plugins, [
-  { pc, {git, "git://github.com:blt/port_compiler.git", {tag, "v1.6.0"}}}
+  { pc, {git, "git://github.com/blt/port_compiler.git", {tag, "v1.6.0"}}}
  ]}.
 
 %% change -DDLOG_DEFAULT=DLOG_DEBUG

--- a/rebar.config
+++ b/rebar.config
@@ -2,7 +2,7 @@
 %% Config file for afunix-application
 {erl_opts, [debug_info]}.
 {plugins, [
-  { pc, {git, "git@github.com:blt/port_compiler.git", {tag, "v1.6.0"}}}
+  { pc, {git, "git://github.com:blt/port_compiler.git", {tag, "v1.6.0"}}}
  ]}.
 
 %% change -DDLOG_DEFAULT=DLOG_DEBUG

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -1,0 +1,6 @@
+case erlang:function_exported(rebar3, main, 1) of
+  true -> % rebar3
+    CONFIG;
+  false -> % rebar 2.x or older
+    proplists:delete (plugins, CONFIG)
+end.


### PR DESCRIPTION
For rebar3 this uses the pc plugin, for rebar2 it removes it
via the rebar.config.script as otherwise the plugin tries to
run and complains.